### PR TITLE
[8.0.r1] Build kvh2xml_headers library

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,11 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := kvh2xml_headers
+LOCAL_PROPRIETARY_MODULE := true
+
+LOCAL_EXPORT_C_INCLUDE_DIRS := \
+    $(LOCAL_PATH)/qcom
+
+include $(BUILD_HEADER_LIBRARY)


### PR DESCRIPTION
These headers are used by different parts of the
audio subsystem (AGM, PAL, etc.).