### PR TITLE
[10.0.r1] qcom: Build kvh2xml_headers module

### DIFF
--- a/qcom/Android.bp
+++ b/qcom/Android.bp
@@ -1,0 +1,5 @@
+cc_library_headers {
+    name: "kvh2xml_headers",
+    export_include_dirs: ["."],
+    vendor: true,
+}


### PR DESCRIPTION
This header is used by different parts of the Audioreach framework.